### PR TITLE
portable diffie–hellman

### DIFF
--- a/lib/easy_crypto.py
+++ b/lib/easy_crypto.py
@@ -1,11 +1,13 @@
 #! /usr/bin/env python3
 # easy_crypto.py
 
+import sys, io
+
 from Cryptodome.PublicKey import RSA
 from Cryptodome.Random import get_random_bytes
 from Cryptodome.Cipher import AES, PKCS1_OAEP
+
 import pyDHE
-import io
 
 # shamelessly stolen from https://pycryptodome.readthedocs.io/en/latest/src/examples.html
 
@@ -122,27 +124,32 @@ def decrypt_aes(data, key):
 
     return plaintext
 
-def DH_generate_private_key():
-
+def generate_dh():
+    """Generates a DHE object (private)."""
     private_key = pyDHE.new()
     return private_key
 
-def DH_get_public_key(client_private_key):
+def export_dh_public(client_private_key):
+    """Given a DHE object, returns a (portable) bytes public key."""
     if not isinstance(client_private_key, pyDHE.DHE):
         raise ValueError("param @client_private_key must be of type pyDHE.DHE")
 
     public_key = client_private_key.getPublicKey()
-    return public_key
+    return public_key.to_bytes(256, byteorder=sys.byteorder)
 
-def DH_generate_shared_secret(client_private_key, peer_public_key):
+def generate_dh_shared_secret(client_private_key, peer_public_key):
+    """
+    Given a DHE private object and a bytes public key,
+    generates and returns a bytes shared secret.
+    """
     if not isinstance(client_private_key, pyDHE.DHE):
         raise ValueError("param @peer_public_key must be type PyDHE")
-    if not isinstance(peer_public_key, int):
-        raise ValueError("param @client_private_key must be of type int")
+    if not isinstance(peer_public_key, bytes):
+        raise ValueError("param @client_private_key must be of type bytes")
 
-    shared_key = client_private_key.update(peer_public_key)
+    shared_key = client_private_key.update(int.from_bytes(peer_public_key, byteorder=sys.byteorder))
 
-    return shared_key
+    return shared_key.to_bytes(256, byteorder=sys.byteorder)
 
 # TESTING SCRIPT
 if __name__ == '__main__':
@@ -169,14 +176,14 @@ if __name__ == '__main__':
     print(aes_decrypted.decode("utf-8"))
 
     # Diffie Hellman testing
-    a_private = DH_generate_private_key()
-    b_private = DH_generate_private_key()
+    a_private = generate_dh()
+    b_private = generate_dh()
 
-    a_public = DH_get_public_key(a_private)
-    b_public = DH_get_public_key(b_private)
+    a_public = export_dh_public(a_private)
+    b_public = export_dh_public(b_private)
 
-    a_shared = DH_generate_shared_secret(a_private, b_public)
-    b_shared = DH_generate_shared_secret(b_private, a_public)
+    a_shared = generate_dh_shared_secret(a_private, b_public)
+    b_shared = generate_dh_shared_secret(b_private, a_public)
 
     if a_shared == b_shared:
         print("DH derived same number")

--- a/lib/easy_crypto.py
+++ b/lib/easy_crypto.py
@@ -2,10 +2,18 @@
 # easy_crypto.py
 
 import sys, io
+from sys import platform
 
-from Cryptodome.PublicKey import RSA
-from Cryptodome.Random import get_random_bytes
-from Cryptodome.Cipher import AES, PKCS1_OAEP
+if platform == "linux":
+    from Cryptodome.PublicKey import RSA
+    from Cryptodome.Random import get_random_bytes
+    from Cryptodome.Cipher import AES, PKCS1_OAEP
+elif platform == "darwin":
+    from Crypto.PublicKey import RSA
+    from Crypto.Random import get_random_bytes
+    from Crypto.Cipher import AES, PKCS1_OAEP
+else: # e.g. platform == "win32":
+    raise NotImplementedError(f"no support for sys.platform:{platform}")
 
 import pyDHE
 

--- a/lib/easy_crypto.py
+++ b/lib/easy_crypto.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-# easy_crypto.py
+# lib/easy_crypto.py
 
 import sys, io
 from sys import platform

--- a/lib/payload.py
+++ b/lib/payload.py
@@ -1,3 +1,6 @@
+#! /usr/bin/env python3
+# lib/payload.py
+
 import io
 from collections import namedtuple
 

--- a/test/test_dhe.py
+++ b/test/test_dhe.py
@@ -1,3 +1,6 @@
+#! /usr/bin/env python3
+# test/test_dhe.py
+
 import sys, os
 sys.path.append(os.path.abspath('../Kudu'))
 

--- a/test/test_dhe.py
+++ b/test/test_dhe.py
@@ -1,0 +1,13 @@
+import sys, os
+sys.path.append(os.path.abspath('../Kudu'))
+
+from lib import easy_crypto as ec
+
+Alice = ec.generate_dh()
+Bob = ec.generate_dh()
+aliceFinal = ec.generate_dh_shared_secret(Alice, ec.export_dh_public(Bob))
+bobFinal = ec.generate_dh_shared_secret(Bob, ec.export_dh_public(Alice))
+
+print(aliceFinal == bobFinal)
+
+# print(int(bin(bobFinal), base=2) == aliceFinal)

--- a/test/test_payload.py
+++ b/test/test_payload.py
@@ -1,3 +1,6 @@
+#! /usr/bin/env python3
+# test/test_payload.py
+
 import sys, os
 
 sys.path.append(os.path.abspath('../Kudu'))


### PR DESCRIPTION
convert output of diffie–hellman values from python ints to byte strings for portability (e.g. http transfers)

note it's a bit sloppy: 256 bytes (from group default: 14 - 2048 bits) is a magic number taken from the library and not parameterized